### PR TITLE
Adding a call to destroy the client queue

### DIFF
--- a/src/service/client.js
+++ b/src/service/client.js
@@ -83,6 +83,7 @@ GatewayClient.prototype.dispose = function() {
                 this.logger.verbose('Unable to close clientQueue ' + this.clientQueue);
             }
         }
+        this.clientQueue.destroy();
         this.clientQueue = undefined;
     }
 


### PR DESCRIPTION
Adding a call to queue.destroy() to get rid of old queues, not just disconnect the channel from them.
